### PR TITLE
fix: 타이머 초기 시간 설정이 적용되지 않는 문제 수정

### DIFF
--- a/app/src/main/java/com/example/myapplication/ThirdActivity.kt
+++ b/app/src/main/java/com/example/myapplication/ThirdActivity.kt
@@ -402,15 +402,27 @@ class ThirdActivity : AppCompatActivity() {
         val prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
 
         timerState = TimerState.entries[prefs.getInt(KEY_TIMER_STATE, 0)]
-        secondsRemaining = prefs.getLong(KEY_SECONDS_REMAINING, 0)
-        timerLengthSeconds = prefs.getLong(KEY_TIMER_LENGTH, WORK_TIME_MINUTES * 60)
         isWorkTime = prefs.getBoolean(KEY_IS_WORK_TIME, true)
         pomodoroCount = prefs.getInt(KEY_POMODORO_COUNT, 0)
 
-        // 초기 설정
-        if (secondsRemaining == 0L) {
-            secondsRemaining = WORK_TIME_MINUTES * 60
-            timerLengthSeconds = WORK_TIME_MINUTES * 60
+        // 타이머가 정지 상태일 때는 항상 새로운 시간 설정 적용
+        if (timerState == TimerState.STOPPED) {
+            if (isWorkTime) {
+                secondsRemaining = WORK_TIME_MINUTES * 60
+                timerLengthSeconds = WORK_TIME_MINUTES * 60
+            } else {
+                // 휴식 시간 설정
+                timerLengthSeconds = if (pomodoroCount % 4 == 0 && pomodoroCount > 0) {
+                    LONG_BREAK_TIME_MINUTES * 60
+                } else {
+                    BREAK_TIME_MINUTES * 60
+                }
+                secondsRemaining = timerLengthSeconds
+            }
+        } else {
+            // 타이머가 실행 중이거나 일시정지 상태일 때만 저장된 값 사용
+            secondsRemaining = prefs.getLong(KEY_SECONDS_REMAINING, WORK_TIME_MINUTES * 60)
+            timerLengthSeconds = prefs.getLong(KEY_TIMER_LENGTH, WORK_TIME_MINUTES * 60)
         }
 
         binding.textPomodoroCount.text = getString(R.string.pomodoro_count_format, pomodoroCount)


### PR DESCRIPTION
## 문제점
- WORK_TIME_MINUTES를 12시간(12L * 60L)으로 변경했지만 실제로 적용되지 않음
- SharedPreferences에 저장된 이전 값이 계속 사용되어 새로운 설정이 반영되지 않음

## 해결 방법
- `restoreTimerState()` 함수에서 타이머 상태에 따라 다르게 처리하도록 수정
  - **STOPPED 상태일 때**: 항상 새로운 설정값(12시간) 적용
  - **RUNNING/PAUSED 상태일 때**: 저장된 값 사용하여 진행 중인 타이머 유지

## 결과
이제 앱을 재시작해도 초기 시간이 12시간으로 정상 적용됩니다.

## 변경 사항
- `ThirdActivity.kt`의 `restoreTimerState()` 함수 수정